### PR TITLE
feat: project lifecycle skills (create/archive)

### DIFF
--- a/.claude/skills/_sub/fetch-projects/SKILL.md
+++ b/.claude/skills/_sub/fetch-projects/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: fetch-projects
+description: List projects from 01_Projects/ (active) and 04_Archives/Projects/ (archived). Returns structured data with title, deadline, status, and timeline urgency.
+disable-model-invocation: true
+allowed-tools: Read, Bash(ls), Glob
+argument-hint: "[scope: active|archived|all]"
+---
+
+# Fetch Projects Sub-Skill
+
+Scans both active and archived project folders and returns structured data for project lifecycle management.
+
+## Prerequisites
+
+This sub-skill expects `$VAULT` to be set by the calling skill (via `fetch-config`).
+
+## Arguments
+
+- `scope` - Optional. Filter by project location:
+  - `active` (default) - Only projects in `01_Projects/`
+  - `archived` - Only projects in `04_Archives/Projects/`
+  - `all` - Both active and archived projects
+
+## File Locations
+
+- **Active projects:** `$VAULT/01_Projects/`
+- **Archived projects:** `$VAULT/04_Archives/Projects/`
+- **Hub files (excluded):** `✱ Projects.md` in either folder
+
+## Execution Steps
+
+### 1. Determine Folders to Scan
+
+Based on `scope` argument:
+
+| Scope | Folders |
+|-------|---------|
+| `active` | `$VAULT/01_Projects/` |
+| `archived` | `$VAULT/04_Archives/Projects/` |
+| `all` | Both folders |
+
+### 2. List Project Files
+
+For each folder, list all `.md` files:
+
+```bash
+ls -1 "$VAULT/01_Projects/"*.md 2>/dev/null | grep -v "✱ Projects.md"
+ls -1 "$VAULT/04_Archives/Projects/"*.md 2>/dev/null | grep -v "✱ Projects.md"
+```
+
+If a folder is empty or missing, continue with other folders (don't fail).
+
+### 3. For Each Project File
+
+Read the file and parse:
+
+#### Extract Slug from Filename
+
+Parse the filename to extract the project slug:
+
+| Filename Pattern | Slug |
+|------------------|------|
+| `2026-03-31-quarterly-planning.md` | `quarterly-planning` |
+| `2026-02-15-hiring-round.md` | `hiring-round` |
+| `platform-migration.md` | `platform-migration` |
+
+**Rules:**
+1. Remove `.md` extension
+2. Remove leading date pattern (`YYYY-MM-DD-`) if present
+3. Remainder is the slug
+
+#### Frontmatter Fields
+
+- `title` - Project name
+- `end_date` - Deadline (YYYY-MM-DD)
+- `status` - `active`, `completed`, `on-hold`, or `archived`
+- `owner` - Project owner
+- `tags` - Array of tags
+
+#### Milestones Table (Optional)
+
+Parse the `## Milestones` section table if present:
+
+```markdown
+| Date | Milestone | Status |
+|------|-----------|--------|
+| 2026-02-15 | Phase 1 | 🔵 In Progress |
+| 2026-03-01 | Phase 2 | 🟡 Planned |
+```
+
+Extract the first milestone where status is NOT `🟢 Complete`.
+
+### 4. Determine Source Location
+
+For each project, set `source`:
+
+| Folder | Source Value |
+|--------|--------------|
+| `01_Projects/` | `active` |
+| `04_Archives/Projects/` | `archived` |
+
+### 5. Calculate Timeline Urgency
+
+For each project with an `end_date`, calculate relative to today:
+
+- `days_remaining` = end_date - today (can be negative if overdue)
+- `timeline_urgency`:
+  - `overdue` if `end_date < today`
+  - `due_soon` if `end_date < today + 14 days`
+  - `on_track` otherwise
+
+For archived projects, timeline_urgency is always `null` (historical).
+
+### 6. Sort Results
+
+Sort by `end_date` ascending (earliest deadlines first). Projects without `end_date` appear last.
+
+### 7. Return Structured Result
+
+**Success (with projects):**
+```json
+{
+  "success": true,
+  "count": 4,
+  "scope": "all",
+  "active_count": 2,
+  "archived_count": 2,
+  "projects": [
+    {
+      "file": "2026-02-20-hiring-round.md",
+      "path": "/path/to/vault/01_Projects/2026-02-20-hiring-round.md",
+      "slug": "hiring-round",
+      "source": "active",
+      "title": "Assessment Center Hiring",
+      "end_date": "2026-02-20",
+      "days_remaining": 5,
+      "timeline_urgency": "due_soon",
+      "status": "active",
+      "owner": "Michael",
+      "tags": ["hiring", "Q1"],
+      "next_milestone": {
+        "date": "2026-02-18",
+        "name": "Final Interviews",
+        "status": "🔵 In Progress"
+      }
+    },
+    {
+      "file": "2026-03-31-quarterly-planning.md",
+      "path": "/path/to/vault/01_Projects/2026-03-31-quarterly-planning.md",
+      "slug": "quarterly-planning",
+      "source": "active",
+      "title": "Q2 Roadmap Planning",
+      "end_date": "2026-03-31",
+      "days_remaining": 44,
+      "timeline_urgency": "on_track",
+      "status": "active",
+      "owner": "Michael",
+      "tags": ["planning", "Q1"],
+      "next_milestone": null
+    },
+    {
+      "file": "2025-12-31-platform-migration.md",
+      "path": "/path/to/vault/04_Archives/Projects/2025-12-31-platform-migration.md",
+      "slug": "platform-migration",
+      "source": "archived",
+      "title": "Platform Migration",
+      "end_date": "2025-12-31",
+      "days_remaining": null,
+      "timeline_urgency": null,
+      "status": "completed",
+      "owner": "Michael",
+      "tags": ["infrastructure"],
+      "next_milestone": null
+    }
+  ]
+}
+```
+
+**Success (no projects found):**
+```json
+{
+  "success": true,
+  "count": 0,
+  "scope": "active",
+  "active_count": 0,
+  "archived_count": 0,
+  "projects": [],
+  "message": "No projects found in 01_Projects/"
+}
+```
+
+**Folder Not Found (all folders missing):**
+```json
+{
+  "success": false,
+  "error": "folders_not_found",
+  "message": "No project folders found at $VAULT/01_Projects/ or $VAULT/04_Archives/Projects/",
+  "suggestion": "Create the 01_Projects/ folder and add project files."
+}
+```
+
+### 8. Human-Readable Summary
+
+For backwards compatibility, also output human-readable summary:
+
+```
+Projects: 4 found (2 active, 2 archived)
+
+Active Projects:
+1. Assessment Center Hiring [hiring-round]
+   Due: 2026-02-20 (5 days) ⚠️ Due Soon
+   Status: active | Owner: Michael
+   Next: Final Interviews (2026-02-18) 🔵 In Progress
+
+2. Q2 Roadmap Planning [quarterly-planning]
+   Due: 2026-03-31 (44 days) ✅ On Track
+   Status: active | Owner: Michael
+
+Archived Projects:
+3. Platform Migration [platform-migration]
+   Ended: 2025-12-31
+   Status: completed | Owner: Michael
+```
+
+## Timeline Urgency Indicators
+
+| Urgency | Condition | Display |
+|---------|-----------|---------|
+| `overdue` | end_date < today | ❗ Overdue |
+| `due_soon` | end_date < today + 14 days | ⚠️ Due Soon |
+| `on_track` | otherwise | ✅ On Track |
+| `null` | archived project | (no indicator) |
+
+## Error Handling
+
+| Error Code | Condition | Behavior |
+|------------|-----------|----------|
+| `folders_not_found` | Neither folder exists | Return error |
+| `parse_error` | Single file can't be parsed | Log warning, skip file, continue |
+| `no_frontmatter` | File has no frontmatter | Skip file, continue |
+
+## Notes
+
+- This skill supersedes `fetch-active-projects` for project lifecycle workflows
+- The `slug` field enables linking projects across documents (e.g., `[[quarterly-planning]]`)
+- Archived projects have `timeline_urgency: null` since deadlines are historical
+- Files without `end_date` are sorted to the end of the list

--- a/.claude/skills/_sub/project-sync-finder/SKILL.md
+++ b/.claude/skills/_sub/project-sync-finder/SKILL.md
@@ -1,0 +1,93 @@
+# project-sync-finder
+
+```yaml
+name: project-sync-finder
+description: Sync project folder structure in Finder (NOT IMPLEMENTED)
+status: stub
+version: 0.0.0
+interface:
+  action: string    # "create" | "archive"
+  vault: string     # Path to vault
+  project: object   # Project frontmatter with slug, due_date, etc.
+outputs:
+  FINDER_PATH: string  # Path to created/archived folder
+```
+
+---
+
+## Status: NOT IMPLEMENTED
+
+This is a placeholder stub documenting the planned interface for Finder project folder synchronization.
+
+## Planned Interface
+
+**Arguments:**
+- `action`: `"create"` or `"archive"`
+- `vault`: Path to the vault root
+- `project`: Project frontmatter object containing at minimum:
+  - `slug`: Project identifier (e.g., `acme-launch`)
+  - `due_date`: Target completion date (e.g., `2026-Q1`)
+  - `title`: Human-readable project name
+
+**Outputs:**
+- `FINDER_PATH`: Absolute path to the created or archived folder
+
+## Planned Functionality
+
+### Create Action
+
+When `action: create`:
+
+1. Read `finder_projects_path` from `.claude/config.md` (default: `~/Projects`)
+2. Create folder structure:
+   ```
+   ~/Projects/{due_date}-{slug}/
+   ├── Assets/
+   └── Documents/
+   ```
+3. Example: `~/Projects/2026-Q1-acme-launch/Assets/`
+
+### Archive Action
+
+When `action: archive`:
+
+1. Move project folder to archive:
+   ```
+   mv ~/Projects/{due_date}-{slug} ~/Projects/_Archive/
+   ```
+2. Preserve internal structure
+
+## Configuration
+
+Will read from `.claude/config.md`:
+
+```markdown
+finder_projects_path: ~/Projects
+```
+
+If not specified, defaults to `~/Projects`.
+
+## Implementation Notes
+
+For the future developer implementing this skill:
+
+1. **Path resolution**: Expand `~` to full home directory path
+2. **Idempotency**: Check if folder exists before creating; skip if already present
+3. **Error handling**: Gracefully handle permission errors, disk full, etc.
+4. **Slug sanitization**: Ensure slug is filesystem-safe (no spaces, special chars)
+5. **Archive subfolder**: Create `_Archive/` if it doesn't exist
+6. **Integration**: This skill will be called by `project-sync` orchestrator alongside `project-sync-vault`
+
+## Example Usage (Future)
+
+```yaml
+# In phases.yaml
+- name: sync-finder
+  skill: _sub/project-sync-finder
+  args:
+    action: "{{ACTION}}"
+    vault: "{{VAULT}}"
+    project: "{{PROJECT}}"
+  outputs:
+    FINDER_PATH: FINDER_PATH
+```

--- a/.claude/skills/_sub/project-sync-outlook/SKILL.md
+++ b/.claude/skills/_sub/project-sync-outlook/SKILL.md
@@ -1,0 +1,87 @@
+# project-sync-outlook
+
+---
+name: project-sync-outlook
+description: Sync project lifecycle actions to Outlook mail folders (NOT IMPLEMENTED)
+status: stub
+---
+
+> **Status: NOT IMPLEMENTED**
+>
+> This is a placeholder documenting the planned interface for future Outlook integration.
+
+## Interface
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | yes | `create` or `archive` |
+| `vault` | path | yes | Path to the vault root |
+| `project` | string | yes | Project name |
+
+## Planned Functionality
+
+### Create Action
+
+Create a mail folder for the project under the configured projects folder.
+
+- Creates folder at `Projects/{project-name}/`
+- Sets up any folder-level rules if supported
+
+### Archive Action
+
+Move the project mail folder to the archive location.
+
+- Moves folder from `Projects/{project-name}/` to `Projects/Archive/{project-name}/`
+- Preserves all mail within the folder
+
+## Configuration
+
+Will read from `.claude/config.md`:
+
+```markdown
+outlook_enabled: true
+outlook_projects_folder: Projects
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `outlook_enabled` | `false` | Enable Outlook integration |
+| `outlook_projects_folder` | `Projects` | Root folder for project mail folders |
+
+## Implementation Options
+
+### Option 1: Microsoft Graph API (Recommended)
+
+- **Pros:** Cross-platform, official API, rich functionality
+- **Cons:** Requires OAuth setup, Azure app registration
+- **Auth:** OAuth 2.0 with delegated permissions
+- **Permissions needed:** `Mail.ReadWrite`, `MailboxSettings.ReadWrite`
+
+### Option 2: AppleScript (macOS only)
+
+- **Pros:** No external dependencies, simple setup
+- **Cons:** macOS only, limited to local Outlook app, fragile
+- **Requirements:** Microsoft Outlook for Mac installed
+
+## Implementation Notes
+
+When implementing this skill:
+
+1. **Check `outlook_enabled`** — Skip silently if disabled
+2. **Handle missing Outlook gracefully** — Warn but don't fail
+3. **Idempotent operations** — Create should no-op if folder exists
+4. **Error messages** — Provide actionable guidance for auth issues
+
+### Graph API Skeleton
+
+```bash
+# Future implementation will use Microsoft Graph
+# Endpoint: POST /me/mailFolders/{parent-id}/childFolders
+# Body: { "displayName": "project-name" }
+```
+
+### Testing Considerations
+
+- Mock Graph API responses for unit tests
+- Integration tests require test tenant or personal account
+- Consider dry-run mode for validation without side effects

--- a/.claude/skills/_sub/project-sync-vault/SKILL.md
+++ b/.claude/skills/_sub/project-sync-vault/SKILL.md
@@ -84,7 +84,7 @@ tags: []
 
 **Why Now:** [Context for why this project matters and why you're doing it now]
 
-**End Date:** {due_date}
+**End Date:** {due_date} - [Brief reason for this timeline]
 
 ---
 
@@ -107,6 +107,8 @@ tags: []
 
 | Date | Milestone | Status |
 |------|-----------|--------|
+| [YYYY-MM-DD] | [First milestone] | 🟡 Planned |
+| [YYYY-MM-DD] | [Second milestone] | 🟡 Planned |
 | {due_date} | Project Completion | 🟡 Planned |
 
 *Status: 🟡 Planned | 🔵 In Progress | 🟢 Complete | 🔴 Blocked*
@@ -120,16 +122,24 @@ tags: []
 ### {today_date} - Project Created
 - Created via project lifecycle skill
 - Initial outcomes defined
+- [Key stakeholders involved]
+
+### [YYYY-MM-DD] - [Brief headline]
+- [Key progress or decision]
+- [Blockers or concerns]
+- [Next steps]
 
 ---
 
 ## Resources
 
 ### Links
-- [Add relevant links]
+- [Documentation link]
+- [Design files]
+- [Project board/tracker]
 
 ### Related Projects
-- [Add related projects]
+- [[related-project-name]] - [How they relate]
 
 ### People
 {for each person in people}
@@ -253,25 +263,19 @@ If a summary is provided in `project.summary`, fill in the Archive Notes section
 **Impact:** {summary.impact or "[To be assessed]"}
 ```
 
-### 6. Write to Archive Location
+### 6. Update Source File
 
-Write the updated content to:
+Write the updated content back to the source file (with updated frontmatter and archive notes).
 
-```
-$VAULT/04_Archives/Projects/{original_filename}
-```
+### 7. Move to Archive
 
-Preserve the original filename (e.g., `2026-03-15-platform-migration.md`).
-
-### 7. Remove Source File
-
-After successful write and verification, remove the original:
+Move the updated file to the archive location:
 
 ```bash
-mv "$SOURCE_PATH" "$ARCHIVE_PATH"
+mv "$SOURCE_PATH" "$VAULT/04_Archives/Projects/{original_filename}"
 ```
 
-Note: Use `mv` to ensure atomic operation. If the write was already done, just remove the source.
+Use `mv` for an atomic move operation. Preserve the original filename (e.g., `2026-03-15-platform-migration.md`).
 
 ### 8. Return Result
 

--- a/.claude/skills/_sub/project-sync-vault/SKILL.md
+++ b/.claude/skills/_sub/project-sync-vault/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: project-sync-vault
+description: Create or archive a project in the vault. Handles creating new project files in 01_Projects/ and archiving completed projects to 04_Archives/Projects/.
+disable-model-invocation: true
+allowed-tools: Read, Write, Bash(ls, mv, mkdir)
+argument-hint: "action=create|archive project={{PROJECT}}"
+---
+
+# Project Sync Vault Sub-Skill
+
+Creates new project files or archives completed projects in the vault.
+
+## Input Arguments
+
+Arguments are passed as key-value pairs:
+
+- `action`: Required. Either `create` or `archive`
+- `vault`: Path to the vault
+- `project`: Object containing project data:
+  - `name`: Project title
+  - `slug`: URL-friendly identifier (e.g., "hiring-round")
+  - `due_date`: Target completion date (YYYY-MM-DD)
+  - `purpose`: Why this project exists
+  - `outcomes`: Array of expected outcomes
+  - `people`: Array of people involved
+  - `path`: Full path to project file (required for archive action)
+
+---
+
+## Action: Create
+
+Creates a new project file in `$VAULT/01_Projects/`.
+
+### 1. Build File Path
+
+Construct the file path:
+
+```
+$VAULT/01_Projects/{due_date}-{slug}.md
+```
+
+Example: `$VAULT/01_Projects/2026-03-15-platform-migration.md`
+
+### 2. Check for Duplicates
+
+Check if a project with the same slug already exists:
+
+```bash
+ls "$VAULT/01_Projects/"*-{slug}.md 2>/dev/null
+```
+
+If file exists, return error:
+```json
+{
+  "success": false,
+  "error": "duplicate_slug",
+  "message": "A project with slug '{slug}' already exists",
+  "existing_path": "/path/to/existing/file.md"
+}
+```
+
+### 3. Generate Content
+
+Generate project content using this template structure:
+
+```markdown
+---
+title: {name}
+end_date: {due_date}
+status: active
+owner: [To be assigned]
+tags: []
+---
+
+[[03_Resources/Brain/✱ Home|✱ Home]] | [[01_Projects/✱ Projects|✱ Projects]] | [[02_Areas/People/✱ People|✱ People]] | [[02_Areas/Insights/✱ Insights|✱ Insights]]
+
+---
+
+# {name}
+
+## Overview
+
+**Goal:** {purpose}
+
+**Why Now:** [Context for why this project matters and why you're doing it now]
+
+**End Date:** {due_date}
+
+---
+
+## Outcomes
+
+### Must Have
+{for each outcome in outcomes}
+- [ ] {outcome}
+{end for}
+
+### Should Have
+- [ ] [Important but not critical outcome]
+
+### Could Have
+- [ ] [Nice-to-have if time permits]
+
+---
+
+## Milestones
+
+| Date | Milestone | Status |
+|------|-----------|--------|
+| {due_date} | Project Completion | 🟡 Planned |
+
+*Status: 🟡 Planned | 🔵 In Progress | 🟢 Complete | 🔴 Blocked*
+
+---
+
+## Updates
+
+*Rituals append chronological updates here. Most recent first.*
+
+### {today_date} - Project Created
+- Created via project lifecycle skill
+- Initial outcomes defined
+
+---
+
+## Resources
+
+### Links
+- [Add relevant links]
+
+### Related Projects
+- [Add related projects]
+
+### People
+{for each person in people}
+- [[{person}]] - [Role TBD]
+{end for}
+
+---
+
+## Team
+
+| Name | Role | Involvement |
+|------|------|-------------|
+{for each person in people}
+| {person} | [Role] | [Involvement] |
+{end for}
+
+---
+
+## Archive Notes
+
+*When project completes, add final summary before moving to Archives:*
+
+**Final Status:** [Success/Partial/Failed]
+**Key Learnings:** [What went well, what didn't]
+**Impact:** [Actual outcomes achieved]
+```
+
+### 4. Write File
+
+Write the generated content to the file path.
+
+### 5. Verify Write
+
+Read back the file to confirm write succeeded.
+
+### 6. Return Result
+
+**Success:**
+```json
+{
+  "success": true,
+  "action": "create",
+  "path": "/Users/.../01_Projects/2026-03-15-platform-migration.md",
+  "project": {
+    "name": "Platform Migration",
+    "slug": "platform-migration",
+    "due_date": "2026-03-15"
+  },
+  "bytes_written": 2048
+}
+```
+
+---
+
+## Action: Archive
+
+Archives a completed project from `01_Projects/` to `04_Archives/Projects/`.
+
+### 1. Validate Source
+
+Verify the source file exists:
+
+```bash
+ls "$VAULT/01_Projects/"*-{slug}.md 2>/dev/null
+```
+
+Or use the provided `project.path` if available.
+
+If source doesn't exist:
+```json
+{
+  "success": false,
+  "error": "source_not_found",
+  "message": "Project file not found in 01_Projects/",
+  "expected_path": "/path/to/01_Projects/*-{slug}.md"
+}
+```
+
+### 2. Ensure Archive Directory
+
+Create archive directory if needed:
+
+```bash
+mkdir -p "$VAULT/04_Archives/Projects/"
+```
+
+### 3. Read Current Content
+
+Read the existing project file content.
+
+### 4. Update Frontmatter
+
+Update the frontmatter with archive metadata:
+
+```yaml
+---
+title: {name}
+end_date: {due_date}
+status: archived
+archived_date: {today_date}
+owner: [existing value]
+tags: [existing tags]
+---
+```
+
+Key changes:
+- Set `status: archived`
+- Add `archived_date: {today_date}` (YYYY-MM-DD format)
+
+### 5. Fill Archive Notes (If Summary Provided)
+
+If a summary is provided in `project.summary`, fill in the Archive Notes section:
+
+```markdown
+## Archive Notes
+
+*When project completes, add final summary before moving to Archives:*
+
+**Final Status:** {summary.status or "Completed"}
+**Key Learnings:** {summary.learnings or "[To be documented]"}
+**Impact:** {summary.impact or "[To be assessed]"}
+```
+
+### 6. Write to Archive Location
+
+Write the updated content to:
+
+```
+$VAULT/04_Archives/Projects/{original_filename}
+```
+
+Preserve the original filename (e.g., `2026-03-15-platform-migration.md`).
+
+### 7. Remove Source File
+
+After successful write and verification, remove the original:
+
+```bash
+mv "$SOURCE_PATH" "$ARCHIVE_PATH"
+```
+
+Note: Use `mv` to ensure atomic operation. If the write was already done, just remove the source.
+
+### 8. Return Result
+
+**Success:**
+```json
+{
+  "success": true,
+  "action": "archive",
+  "source_path": "/Users/.../01_Projects/2026-03-15-platform-migration.md",
+  "archive_path": "/Users/.../04_Archives/Projects/2026-03-15-platform-migration.md",
+  "project": {
+    "name": "Platform Migration",
+    "slug": "platform-migration",
+    "due_date": "2026-03-15",
+    "archived_date": "2026-02-15"
+  },
+  "bytes_written": 2560
+}
+```
+
+---
+
+## Error Cases
+
+| Condition | Error Code | Message |
+|-----------|------------|---------|
+| Invalid action | `invalid_action` | "Action must be 'create' or 'archive'" |
+| Missing vault | `vault_not_found` | "Vault directory does not exist: {vault}" |
+| Missing required fields | `missing_fields` | "Missing required fields: {fields}" |
+| Duplicate slug (create) | `duplicate_slug` | "A project with slug '{slug}' already exists" |
+| Source not found (archive) | `source_not_found` | "Project file not found in 01_Projects/" |
+| Write failed | `write_failed` | "Failed to write file: {system_error}" |
+| Move failed | `move_failed` | "Failed to move file to archive: {system_error}" |
+| Verification failed | `verification_failed` | "Write verification failed" |
+
+---
+
+## Output Format
+
+Always return structured JSON for both success and error cases.
+
+**Success structure:**
+```json
+{
+  "success": true,
+  "action": "create|archive",
+  "path": "...",
+  "project": { ... },
+  "bytes_written": ...
+}
+```
+
+**Error structure:**
+```json
+{
+  "success": false,
+  "error": "error_code",
+  "message": "Human-readable message",
+  "suggestion": "Optional guidance for resolution"
+}
+```
+
+---
+
+## Safety
+
+- Validate all paths are within expected directories before any write/move
+- For create: Only write to `01_Projects/`
+- For archive: Only read from `01_Projects/`, only write to `04_Archives/Projects/`
+- Never overwrite existing files without explicit confirmation
+- Always verify writes succeeded before confirming success

--- a/.claude/skills/commands/archive-project/SKILL.md
+++ b/.claude/skills/commands/archive-project/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: archive-project
+description: Archive a completed project. Captures final summary and moves to archives across synced tools.
+argument-hint: "[project-slug]"
+metadata:
+  orchestrated: true
+  phases_file: phases.yaml
+---
+
+# Archive Project Command
+
+Interactive workflow for archiving completed projects with summary capture and vault sync.
+
+## Flow Overview
+
+```
+Setup → Select → Interact (summary) → Generate → Sync → Confirm
+```
+
+1. **Setup** - Fetch configuration and active projects list
+2. **Select** - Present active projects, user picks one to archive
+3. **Interact** - Walk through summary questions with user
+4. **Generate** - Build archive data object from responses
+5. **Sync** - Move to vault archive (and future integrations)
+6. **Confirm** - Show summary of archived artifacts
+
+---
+
+## Setup Phase
+
+Load configuration and active projects:
+- Get vault path for file operations
+- Fetch list of active projects for selection
+
+---
+
+## Select Phase
+
+Present the list of active projects for the user to choose from.
+
+### With Argument
+
+If a project slug was provided via `--args`, look up the project:
+
+```bash
+claude skill run commands/archive-project --args "platform-migration"
+```
+
+If found, confirm with user:
+> Found project "Platform Migration" (due: 2026-03-31). Archive this project?
+
+If not found, show available projects and ask user to select.
+
+### Without Argument
+
+Display numbered list of active projects:
+
+```
+Select a project to archive:
+
+1. Assessment Center Hiring [hiring-round]
+   Due: 2026-02-20 (5 days) | Status: active
+
+2. Q2 Roadmap Planning [quarterly-planning]
+   Due: 2026-03-31 (44 days) | Status: active
+
+3. Platform Migration [platform-migration]
+   Due: 2026-04-15 (59 days) | Status: active
+
+Enter project number or slug:
+```
+
+Wait for user selection before proceeding.
+
+---
+
+## Interactive Summary
+
+Guide the user through capturing a final summary with **one question at a time**. Wait for each answer before proceeding.
+
+### Question Flow
+
+#### 1. Final Status (required)
+
+> What's the final status of this project?
+
+Present options:
+- **Completed** - All objectives met, project successful
+- **Partial** - Some objectives met, acceptable outcome
+- **Cancelled** - Project stopped before completion
+- **On-hold** - Project paused indefinitely (will archive but note status)
+
+Accept status selection and confirm.
+
+---
+
+#### 2. Key Wins (required)
+
+> What were the key wins or successes from this project?
+
+Encourage bullet-point format. These populate the "Key Learnings" positive outcomes.
+
+Examples:
+- "Successfully hired 2 senior engineers"
+- "Completed migration with zero downtime"
+- "Delivered 3 weeks ahead of schedule"
+
+---
+
+#### 3. Key Learnings (required)
+
+> What did you learn? What would you do differently next time?
+
+Capture lessons learned, both positive and areas for improvement.
+
+Examples:
+- "Should have involved stakeholders earlier"
+- "The new testing framework saved significant time"
+- "Communication cadence was too infrequent"
+
+---
+
+#### 4. Impact (required)
+
+> What was the actual impact of this project?
+
+Focus on measurable outcomes and business value.
+
+Examples:
+- "Reduced deployment time from 4 hours to 15 minutes"
+- "Team capacity increased by 40%"
+- "Customer satisfaction improved from 3.2 to 4.1"
+
+---
+
+#### 5. Follow-ups (optional)
+
+> Are there any follow-up actions or future projects that came out of this? (Press Enter to skip)
+
+Capture items that should be tracked separately.
+
+Examples:
+- "Need to document the new process"
+- "Consider Phase 2 expansion in Q3"
+- "Schedule retrospective with broader team"
+
+If skipped, leave follow-ups as empty array `[]`.
+
+---
+
+## Generate Phase
+
+After collecting all inputs, build the archive data object:
+
+```json
+{
+  "name": "Platform Migration",
+  "slug": "platform-migration",
+  "due_date": "2026-03-31",
+  "path": "/path/to/01_Projects/2026-03-31-platform-migration.md",
+  "summary": {
+    "status": "completed",
+    "wins": [
+      "Zero downtime migration achieved",
+      "All services running on Kubernetes",
+      "Documentation completed"
+    ],
+    "learnings": [
+      "Should have involved DevOps team earlier",
+      "Canary deployments reduced risk significantly"
+    ],
+    "impact": "Reduced deployment time from 4 hours to 15 minutes. Infrastructure costs reduced by 30%.",
+    "followups": [
+      "Document runbook for common issues",
+      "Plan Phase 2: migrate remaining legacy services"
+    ]
+  }
+}
+```
+
+Display the generated data to the user for confirmation before syncing.
+
+---
+
+## Sync Sequence
+
+Execute sync operations in order. Required syncs must succeed; optional syncs log warnings on failure.
+
+### 1. Vault Sync (required)
+
+Call `project-sync-vault` with:
+- `action`: `archive`
+- `vault`: `{{VAULT}}`
+- `project`: The generated project object with summary
+
+This:
+1. Updates the project file frontmatter with `status: archived` and `archived_date`
+2. Fills in the Archive Notes section with summary data
+3. Moves the file from `$VAULT/01_Projects/` to `$VAULT/04_Archives/Projects/`
+
+**On failure:** Stop and report error to user.
+
+### 2. Finder Sync (optional, future)
+
+*Not yet implemented. Placeholder for macOS Finder folder archival.*
+
+When enabled, would:
+- Move project folder to `~/Archives/Projects/`
+- Update any symlinks
+
+### 3. Outlook Sync (optional, future)
+
+*Not yet implemented. Placeholder for Outlook calendar cleanup.*
+
+When enabled, would:
+- Mark project-related calendar events as completed
+- Remove recurring project meetings
+
+---
+
+## Confirm Phase
+
+Present summary of archived artifacts:
+
+```
+Project Archived: Platform Migration
+
+  From:     $VAULT/01_Projects/2026-03-31-platform-migration.md
+  To:       $VAULT/04_Archives/Projects/2026-03-31-platform-migration.md
+  Archived: February 15, 2026
+
+Summary:
+  Status:    Completed
+
+  Key Wins:
+  - Zero downtime migration achieved
+  - All services running on Kubernetes
+  - Documentation completed
+
+  Key Learnings:
+  - Should have involved DevOps team earlier
+  - Canary deployments reduced risk significantly
+
+  Impact:    Reduced deployment time from 4 hours to 15 minutes. Infrastructure costs reduced by 30%.
+
+  Follow-ups:
+  - Document runbook for common issues
+  - Plan Phase 2: migrate remaining legacy services
+
+Next steps:
+1. Review archived project in $VAULT/04_Archives/Projects/
+2. Create follow-up tasks or projects as needed
+3. Share learnings with your team
+```
+
+---
+
+## Error Handling
+
+| Phase | Error | Behavior |
+|-------|-------|----------|
+| Setup | Config not found | Suggest running `/init` |
+| Setup | Vault not accessible | Report error, abort |
+| Setup | No active projects | Report "No active projects to archive", abort |
+| Select | Invalid selection | Show options again, retry |
+| Select | Project not found | Show available projects, retry |
+| Interact | User cancels | Exit gracefully |
+| Generate | Invalid data | Show validation errors, retry |
+| Sync (vault) | Source not found | Report error, abort |
+| Sync (vault) | Move failed | Report error, abort |
+| Sync (optional) | Any failure | Log warning, continue |
+
+---
+
+## Usage Examples
+
+**With argument:**
+```bash
+claude skill run commands/archive-project --args "platform-migration"
+```
+Pre-selects project, confirms with user before proceeding.
+
+**Without argument:**
+```bash
+claude skill run commands/archive-project
+```
+Shows list of active projects for selection.
+
+---
+
+## Output Variables
+
+After successful execution:
+
+| Variable | Content |
+|----------|---------|
+| `PROJECT` | Selected project data with summary |
+| `VAULT_RESULT` | Result from vault sync (paths, success) |
+| `ARCHIVED_PATH` | Full path to archived project file |

--- a/.claude/skills/commands/archive-project/phases.yaml
+++ b/.claude/skills/commands/archive-project/phases.yaml
@@ -1,0 +1,94 @@
+# Orchestration phases for archive-project command
+# Interactive workflow for archiving completed projects with summary capture
+
+phases:
+  # Phase 0: Setup (parallel, read-only)
+  - name: setup
+    parallel: true
+    subagents:
+      - skill: _sub/fetch-config
+        type: explore
+        output: VAULT
+      - skill: _sub/fetch-projects
+        type: explore
+        args: "scope=active"
+        output: PROJECTS
+        optional: true
+        on_error: "No active projects found to archive."
+
+  # Phase 1: Select Project (inline - requires user)
+  - name: select
+    depends_on: [setup]
+    inline: true
+    description: |
+      Present list of active projects from PROJECTS.
+      If --args provided a slug, look up and confirm.
+      Otherwise, show numbered list for user selection.
+      Store selected project in PROJECT variable.
+
+  # Phase 2: Interactive Summary (inline - requires user)
+  - name: interact
+    depends_on: [select]
+    inline: true
+    description: |
+      Walk through 5 summary questions one at a time:
+      1. Final Status (required) - completed/partial/cancelled/on-hold
+      2. Key Wins (required) - bullet list of successes
+      3. Key Learnings (required) - lessons learned
+      4. Impact (required) - measurable outcomes
+      5. Follow-ups (optional) - future actions
+
+  # Phase 3: Generate Archive Data (inline)
+  - name: generate
+    depends_on: [interact]
+    inline: true
+    description: |
+      Build archive data object from selection and summary responses.
+      Include project metadata and full summary.
+      Confirm with user before syncing.
+
+  # Phase 4: Sync to Vault (required)
+  - name: sync-vault
+    depends_on: [generate]
+    subagents:
+      - skill: _sub/project-sync-vault
+        type: general-purpose
+        args: "action=archive vault={{VAULT}} project={{PROJECT}}"
+        output: VAULT_RESULT
+
+  # Phase 5: Sync to Finder (optional, disabled)
+  - name: sync-finder
+    depends_on: [sync-vault]
+    enabled: false
+    optional: true
+    subagents:
+      - skill: _sub/project-sync-finder
+        type: general-purpose
+        args: "action=archive project={{PROJECT}}"
+        output: FINDER_RESULT
+        optional: true
+        on_error: "Finder sync skipped."
+
+  # Phase 6: Sync to Outlook (optional, disabled)
+  - name: sync-outlook
+    depends_on: [sync-vault]
+    enabled: false
+    optional: true
+    subagents:
+      - skill: _sub/project-sync-outlook
+        type: general-purpose
+        args: "action=archive project={{PROJECT}}"
+        output: OUTLOOK_RESULT
+        optional: true
+        on_error: "Outlook sync skipped."
+
+  # Phase 7: Confirm and Summarize (inline)
+  - name: confirm
+    depends_on: [sync-vault, sync-finder, sync-outlook]
+    inline: true
+    description: |
+      Present summary of archived artifacts:
+      - Source and destination paths
+      - Archive date
+      - Full summary (status, wins, learnings, impact, follow-ups)
+      - Next steps for the user

--- a/.claude/skills/commands/create-project/SKILL.md
+++ b/.claude/skills/commands/create-project/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: create-project
+description: Create a new project with guided setup. Syncs to vault (and future: Finder, Outlook).
+argument-hint: "[project-name]"
+metadata:
+  orchestrated: true
+  phases_file: phases.yaml
+---
+
+# Create Project Command
+
+Interactive wizard for creating new projects with full lifecycle support.
+
+## Flow Overview
+
+```
+Setup → Interact (wizard) → Generate → Sync → Confirm
+```
+
+1. **Setup** - Fetch configuration and existing projects
+2. **Interact** - Walk through wizard questions with user
+3. **Generate** - Build project data object from responses
+4. **Sync** - Create artifacts in vault (and future integrations)
+5. **Confirm** - Show summary of created artifacts
+
+---
+
+## Setup Phase
+
+Load configuration and existing projects to:
+- Get vault path for file creation
+- Check for duplicate project slugs
+- Show context of existing active projects
+
+---
+
+## Interactive Wizard
+
+Guide the user through project creation with **one question at a time**. Wait for each answer before proceeding.
+
+### Question Flow
+
+#### 1. Project Name (required)
+
+> What's the name of your project?
+
+Accept the project name and generate a URL-friendly slug:
+
+| Input | Slug |
+|-------|------|
+| "Platform Migration" | `platform-migration` |
+| "Q2 2026 Roadmap" | `q2-2026-roadmap` |
+| "Hiring: Assessment Center" | `hiring-assessment-center` |
+
+**Slug rules:**
+- Lowercase
+- Replace spaces with hyphens
+- Remove special characters except hyphens
+- Collapse multiple hyphens
+
+If a project argument was provided via `--args`, pre-fill the name and confirm with user.
+
+**Duplicate check:** If slug matches an existing project, warn user and suggest alternatives.
+
+---
+
+#### 2. Due Date (required)
+
+> When should this project be complete?
+
+Accept flexible date formats and normalize to YYYY-MM-DD:
+
+| Input | Normalized |
+|-------|------------|
+| "end of March" | `2026-03-31` |
+| "in 2 weeks" | `2026-03-01` |
+| "March 15" | `2026-03-15` |
+| "2026-04-01" | `2026-04-01` |
+| "Q2" | `2026-06-30` |
+
+Confirm the interpreted date with the user before proceeding.
+
+---
+
+#### 3. Purpose (required)
+
+> In one sentence, what's the goal of this project?
+
+Capture the primary objective. This becomes the project's `purpose` field and drives the "Goal" section.
+
+Examples:
+- "Successfully hire 2 senior engineers through assessment center process"
+- "Migrate all services from legacy platform to Kubernetes"
+- "Define and align on Q2 roadmap with all stakeholders"
+
+---
+
+#### 4. Key Outcomes (optional)
+
+> What are 1-3 key outcomes you want to achieve? (Press Enter to skip)
+
+Accept a bullet list or comma-separated outcomes. These populate the "Must Have" outcomes section.
+
+Format as array:
+```json
+["Hire 2 senior engineers", "Complete onboarding by April", "Document hiring process"]
+```
+
+If skipped, leave outcomes as empty array `[]`.
+
+---
+
+#### 5. Related People (optional)
+
+> Who's involved in this project? (comma-separated names, or Enter to skip)
+
+Accept comma-separated names. These populate the People and Team sections.
+
+Format as array:
+```json
+["Sarah", "Marcus", "Engineering Team"]
+```
+
+If skipped, leave people as empty array `[]`.
+
+---
+
+## Generate Phase
+
+After collecting all inputs, build the project data object:
+
+```json
+{
+  "name": "Platform Migration",
+  "slug": "platform-migration",
+  "due_date": "2026-03-31",
+  "purpose": "Migrate all services from legacy platform to Kubernetes",
+  "outcomes": [
+    "All services running on Kubernetes",
+    "Zero downtime migration",
+    "Documentation complete"
+  ],
+  "people": ["Sarah", "Marcus", "DevOps Team"]
+}
+```
+
+Display the generated data to the user for confirmation before syncing.
+
+---
+
+## Sync Sequence
+
+Execute sync operations in order. Required syncs must succeed; optional syncs log warnings on failure.
+
+### 1. Vault Sync (required)
+
+Call `project-sync-vault` with:
+- `action`: `create`
+- `vault`: `{{VAULT}}`
+- `project`: The generated project object
+
+This creates the project file at `$VAULT/01_Projects/{due_date}-{slug}.md`.
+
+**On failure:** Stop and report error to user.
+
+### 2. Finder Sync (optional, future)
+
+*Not yet implemented. Placeholder for macOS Finder folder creation.*
+
+When enabled, would create:
+- `~/Projects/{slug}/` folder structure
+- Symlink to vault project file
+
+### 3. Outlook Sync (optional, future)
+
+*Not yet implemented. Placeholder for Outlook calendar integration.*
+
+When enabled, would:
+- Create calendar event for due date
+- Add milestone reminders
+
+---
+
+## Confirm Phase
+
+Present summary of created artifacts:
+
+```
+✓ Project Created: Platform Migration
+
+  Vault:    $VAULT/01_Projects/2026-03-31-platform-migration.md
+  Due:      March 31, 2026 (44 days)
+  Purpose:  Migrate all services from legacy platform to Kubernetes
+
+  Outcomes:
+  - All services running on Kubernetes
+  - Zero downtime migration
+  - Documentation complete
+
+  People:   Sarah, Marcus, DevOps Team
+
+Next steps:
+1. Open the project file to add milestones and details
+2. Link project to relevant Area pages
+3. Reference [[platform-migration]] in your daily plans
+```
+
+---
+
+## Error Handling
+
+| Phase | Error | Behavior |
+|-------|-------|----------|
+| Setup | Config not found | Suggest running `/init` |
+| Setup | Vault not accessible | Report error, abort |
+| Interact | User cancels | Exit gracefully |
+| Generate | Invalid data | Show validation errors, retry |
+| Sync (vault) | Duplicate slug | Suggest alternative name |
+| Sync (vault) | Write failed | Report error, abort |
+| Sync (optional) | Any failure | Log warning, continue |
+
+---
+
+## Usage Examples
+
+**With argument:**
+```bash
+claude skill run commands/create-project --args "Platform Migration"
+```
+Pre-fills project name, confirms with user.
+
+**Without argument:**
+```bash
+claude skill run commands/create-project
+```
+Starts wizard from the beginning.
+
+---
+
+## Output Variables
+
+After successful execution:
+
+| Variable | Content |
+|----------|---------|
+| `PROJECT` | Generated project data object |
+| `VAULT_RESULT` | Result from vault sync (path, success) |
+| `CREATED_PATH` | Full path to created project file |

--- a/.claude/skills/commands/create-project/phases.yaml
+++ b/.claude/skills/commands/create-project/phases.yaml
@@ -1,0 +1,83 @@
+# Orchestration phases for create-project command
+# Interactive wizard for creating new projects with vault sync
+
+phases:
+  # Phase 0: Setup (parallel, read-only)
+  - name: setup
+    parallel: true
+    subagents:
+      - skill: _sub/fetch-config
+        type: explore
+        output: VAULT
+      - skill: _sub/fetch-projects
+        type: explore
+        args: "scope=active"
+        output: PROJECTS
+        optional: true
+        on_error: "No existing projects found. First project!"
+
+  # Phase 1: Interactive Wizard (inline - requires user)
+  - name: interact
+    depends_on: [setup]
+    inline: true
+    description: |
+      Walk through 5 wizard questions one at a time:
+      1. Project Name (required) - generate slug
+      2. Due Date (required) - flexible formats
+      3. Purpose (required) - one sentence goal
+      4. Key Outcomes (optional) - 1-3 bullets
+      5. Related People (optional) - comma-separated
+
+  # Phase 2: Generate Project Data (inline)
+  - name: generate
+    depends_on: [interact]
+    inline: true
+    description: |
+      Build project data object from wizard responses.
+      Validate all required fields.
+      Confirm with user before syncing.
+
+  # Phase 3: Sync to Vault (required)
+  - name: sync-vault
+    depends_on: [generate]
+    subagents:
+      - skill: _sub/project-sync-vault
+        type: general-purpose
+        args: "action=create vault={{VAULT}} project={{PROJECT}}"
+        output: VAULT_RESULT
+
+  # Phase 4: Sync to Finder (optional, disabled)
+  - name: sync-finder
+    depends_on: [sync-vault]
+    enabled: false
+    optional: true
+    subagents:
+      - skill: _sub/project-sync-finder
+        type: general-purpose
+        args: "action=create project={{PROJECT}}"
+        output: FINDER_RESULT
+        optional: true
+        on_error: "Finder sync skipped."
+
+  # Phase 5: Sync to Outlook (optional, disabled)
+  - name: sync-outlook
+    depends_on: [sync-vault]
+    enabled: false
+    optional: true
+    subagents:
+      - skill: _sub/project-sync-outlook
+        type: general-purpose
+        args: "action=create project={{PROJECT}}"
+        output: OUTLOOK_RESULT
+        optional: true
+        on_error: "Outlook sync skipped."
+
+  # Phase 6: Confirm and Summarize (inline)
+  - name: confirm
+    depends_on: [sync-vault, sync-finder, sync-outlook]
+    inline: true
+    description: |
+      Present summary of created artifacts:
+      - Vault file path and details
+      - Future: Finder folder, Outlook events
+      - Next steps for the user

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ cd ~/Code/2bd-engine
 claude skill run rituals/planning-daily   # morning
 claude skill run rituals/review-daily     # evening
 claude skill run commands/init --args "profile"   # update profile
+claude skill run commands/create-project          # new project
+claude skill run commands/archive-project         # archive completed project
 ```
 
 ## Documentation

--- a/docs/plans/2026-02-15-project-lifecycle-design.md
+++ b/docs/plans/2026-02-15-project-lifecycle-design.md
@@ -1,0 +1,260 @@
+# Project Lifecycle Skill Design
+
+Create and archive projects across multiple tools with a pluggable sync architecture.
+
+**Date:** 2026-02-15
+**Status:** Approved
+**Issue:** #2
+
+---
+
+## Goals
+
+1. Scaffold extensible project lifecycle skills
+2. Implement vault sync only (MVP)
+3. Prepare architecture for Finder and Outlook sync (future)
+4. Sequential sync phases for partial success and easy debugging
+
+---
+
+## Skill Structure
+
+```
+.claude/skills/
+├── commands/
+│   ├── create-project/
+│   │   ├── SKILL.md
+│   │   └── phases.yaml
+│   └── archive-project/
+│       ├── SKILL.md
+│       └── phases.yaml
+└── _sub/
+    ├── fetch-projects/          # List active projects
+    ├── project-sync-vault/      # MVP: Create/archive in vault
+    ├── project-sync-finder/     # Future: Finder folders
+    └── project-sync-outlook/    # Future: Outlook folders
+```
+
+All `project-sync-*` sub-skills share the same interface:
+- Input: project data + action (create/archive)
+- Output: success/failure + path created
+
+---
+
+## create-project Flow
+
+```yaml
+phases:
+  # Phase 0: Setup
+  - name: setup
+    parallel: true
+    subagents:
+      - skill: _sub/fetch-config
+      - skill: _sub/fetch-directives (optional)
+      - skill: _sub/fetch-projects  # Duplicate detection
+
+  # Phase 1: Interactive wizard (inline)
+  - name: interact
+    depends_on: [setup]
+    inline: true
+
+  # Phase 2: Generate project data (inline)
+  - name: generate
+    depends_on: [interact]
+    inline: true
+
+  # Phase 3+: Sequential syncs
+  - name: sync-vault
+    depends_on: [generate]
+    subagents:
+      - skill: _sub/project-sync-vault
+        args: "action=create project={{PROJECT}}"
+
+  - name: sync-finder      # Future
+    depends_on: [sync-vault]
+    optional: true
+
+  - name: sync-outlook     # Future
+    depends_on: [sync-finder]
+    optional: true
+
+  # Final: Confirm
+  - name: confirm
+    depends_on: [sync-vault]
+    inline: true
+```
+
+### Interactive Wizard Questions
+
+1. **Project Name** (required) — Natural language, auto-generates slug
+2. **Due Date** (required) — Smart parsing: "end of March", "2026-03-31", "in 2 weeks"
+3. **Quick Purpose** (required) — One sentence for the Goal section
+4. **Key Outcomes** (optional) — 1-3 bullet points
+5. **Related People** (optional) — Links to `02_Areas/People/`
+
+---
+
+## archive-project Flow
+
+```yaml
+phases:
+  # Phase 0: Setup
+  - name: setup
+    parallel: true
+    subagents:
+      - skill: _sub/fetch-config
+      - skill: _sub/fetch-projects
+
+  # Phase 1: Select project (inline)
+  - name: select
+    depends_on: [setup]
+    inline: true
+
+  # Phase 2: Final summary (inline)
+  - name: interact
+    depends_on: [select]
+    inline: true
+
+  # Phase 3: Generate archive data (inline)
+  - name: generate
+    depends_on: [interact]
+    inline: true
+
+  # Phase 4+: Sequential syncs
+  - name: sync-vault
+    depends_on: [generate]
+    subagents:
+      - skill: _sub/project-sync-vault
+        args: "action=archive project={{PROJECT}}"
+
+  - name: sync-finder      # Future
+    depends_on: [sync-vault]
+    optional: true
+
+  - name: sync-outlook     # Future
+    depends_on: [sync-finder]
+    optional: true
+
+  # Final: Confirm
+  - name: confirm
+    depends_on: [sync-vault]
+    inline: true
+```
+
+### Archive Interaction
+
+1. Select from active projects list
+2. Capture: key wins, lessons learned, follow-up items
+3. Move project file to `04_Archives/Projects/`
+4. Update status in frontmatter
+
+---
+
+## Sub-skill Interfaces
+
+### fetch-projects
+
+```
+Input:
+  - vault: path
+
+Output:
+  - active_projects[]: name, slug, due_date, path, status
+  - archived_projects[]: same fields
+  - overdue[]: projects past due date
+  - due_soon[]: projects due within 2 weeks
+```
+
+Reads from `01_Projects/` and `04_Archives/Projects/`.
+
+---
+
+### project-sync-vault
+
+```
+Input:
+  - action: "create" | "archive"
+  - vault: path
+  - project: { name, slug, due_date, purpose, outcomes[], people[] }
+
+Output (create):
+  - success: boolean
+  - path: created file path
+  - error: message if failed
+
+Output (archive):
+  - success: boolean
+  - archive_path: new location
+  - error: message if failed
+```
+
+**Create:** Writes to `01_Projects/YYYY-MM-DD-{slug}.md` using project template.
+**Archive:** Moves to `04_Archives/Projects/`, updates frontmatter status.
+
+---
+
+### project-sync-finder (future)
+
+```
+Input: same as project-sync-vault
+Output: same pattern
+
+Create: mkdir ~/Projects/YYYY-MM-DD-{slug}/{Assets,Documents}
+Archive: mv to ~/Projects/_Archive/
+```
+
+---
+
+### project-sync-outlook (future)
+
+```
+Input: same as project-sync-vault
+Output: same pattern
+
+Create: Create mail folder under Projects/
+Archive: Move folder to Projects/Archive/
+```
+
+---
+
+## Scope
+
+### MVP (Phase 1)
+
+- `commands/create-project` — full implementation
+- `commands/archive-project` — full implementation
+- `_sub/fetch-projects` — full implementation
+- `_sub/project-sync-vault` — full implementation
+
+### Future (Phase 2+)
+
+- `_sub/project-sync-finder` — stub now, implement later
+- `_sub/project-sync-outlook` — stub now, implement later
+
+---
+
+## Issue #2 Updates
+
+Original issue scope was too large. This design splits it:
+
+**Keep in Phase 1:**
+- #3 — Implement create-project
+- #4 — Implement archive-project
+- #5 — Implement fetch-projects (was get-projects)
+- #8 — Update documentation
+
+**Move to Phase 2/3 backlog:**
+- #6 — Finder integration
+- #7 — Outlook integration
+
+---
+
+## Architecture Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Sync strategy | Sequential phases | Partial success possible, easier debugging |
+| Sub-skill naming | `project-sync-*` | Lexical grouping |
+| Interface | Shared across all syncs | Easy to add new tools |
+| Future tools | Optional phases | No main skill changes needed |
+| Interaction | Interactive wizard | Original issue requirement |

--- a/docs/plans/2026-02-15-project-lifecycle-implementation.md
+++ b/docs/plans/2026-02-15-project-lifecycle-implementation.md
@@ -1,0 +1,1136 @@
+# Project Lifecycle Skill Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement create-project and archive-project commands with vault sync, scaffolded for future tool integrations.
+
+**Architecture:** Orchestrated skills with sequential sync phases. Each tool sync is a sub-skill following a shared interface. MVP implements vault only; Finder/Outlook are stubs.
+
+**Tech Stack:** Claude skills (SKILL.md + phases.yaml), markdown templates, YAML frontmatter.
+
+---
+
+## Task 1: fetch-projects Sub-Skill
+
+**Files:**
+- Create: `.claude/skills/_sub/fetch-projects/SKILL.md`
+
+**Step 1: Create the sub-skill directory**
+
+```bash
+mkdir -p .claude/skills/_sub/fetch-projects
+```
+
+**Step 2: Write the SKILL.md**
+
+Create `.claude/skills/_sub/fetch-projects/SKILL.md`:
+
+```markdown
+---
+name: fetch-projects
+description: List projects from 01_Projects/ and 04_Archives/Projects/. Returns structured data with title, deadline, status, and timeline urgency.
+disable-model-invocation: true
+allowed-tools: Read, Bash(ls), Glob
+argument-hint: "[scope: active|archived|all]"
+---
+
+# Fetch Projects Sub-Skill
+
+Lists projects from the vault for selection in create/archive workflows.
+
+## Prerequisites
+
+This sub-skill expects `$VAULT` to be set by the calling skill (via `fetch-config`).
+
+## Arguments
+
+- `scope` - Optional. `active` (default), `archived`, or `all`
+
+## File Locations
+
+- **Active projects:** `$VAULT/01_Projects/`
+- **Archived projects:** `$VAULT/04_Archives/Projects/`
+- **Hub file (excluded):** `✱ Projects.md`
+
+## Execution Steps
+
+### 1. List Project Files
+
+For active projects:
+```bash
+ls -1 "$VAULT/01_Projects/"*.md 2>/dev/null | grep -v "✱ Projects.md"
+```
+
+For archived projects (if scope includes):
+```bash
+ls -1 "$VAULT/04_Archives/Projects/"*.md 2>/dev/null
+```
+
+### 2. For Each Project File
+
+Read the file and parse:
+
+**Frontmatter Fields:**
+- `title` - Project name
+- `end_date` - Deadline (YYYY-MM-DD)
+- `status` - `active`, `completed`, `on-hold`, `archived`
+- `owner` - Project owner
+- `tags` - Array of tags
+
+**Extract from filename:**
+- `slug` - The slug portion (e.g., `quarterly-planning` from `2026-03-31-quarterly-planning.md`)
+- `file_date` - The date prefix (e.g., `2026-03-31`)
+
+### 3. Calculate Timeline Urgency
+
+For active projects, calculate relative to today:
+
+- `days_remaining` = end_date - today
+- `timeline_urgency`:
+  - `overdue` if `end_date < today`
+  - `due_soon` if `end_date < today + 14 days`
+  - `on_track` otherwise
+
+### 4. Sort Results
+
+Sort by `end_date` ascending (earliest deadlines first).
+
+### 5. Return Structured Result
+
+**Success:**
+```json
+{
+  "success": true,
+  "active_count": 3,
+  "archived_count": 5,
+  "projects": [
+    {
+      "file": "2026-02-20-hiring-round.md",
+      "path": "/path/to/vault/01_Projects/2026-02-20-hiring-round.md",
+      "slug": "hiring-round",
+      "title": "Assessment Center Hiring",
+      "end_date": "2026-02-20",
+      "days_remaining": 5,
+      "timeline_urgency": "due_soon",
+      "status": "active",
+      "location": "active"
+    }
+  ]
+}
+```
+
+**No Projects:**
+```json
+{
+  "success": true,
+  "active_count": 0,
+  "archived_count": 0,
+  "projects": [],
+  "message": "No projects found"
+}
+```
+
+For backwards compatibility, also output human-readable list:
+```
+Active Projects: 3 found
+
+1. Assessment Center Hiring
+   Slug: hiring-round
+   Due: 2026-02-20 (5 days) ⚠️ Due Soon
+
+2. Platform Migration
+   Slug: platform-migration
+   Due: 2026-03-15 (28 days) ✅ On Track
+```
+```
+
+**Step 3: Verify file created**
+
+```bash
+head -20 .claude/skills/_sub/fetch-projects/SKILL.md
+```
+
+Expected: See the frontmatter and first section.
+
+**Step 4: Commit**
+
+```bash
+git add .claude/skills/_sub/fetch-projects/SKILL.md
+git commit -m "feat(sub-skill): add fetch-projects for project lifecycle"
+```
+
+---
+
+## Task 2: project-sync-vault Sub-Skill
+
+**Files:**
+- Create: `.claude/skills/_sub/project-sync-vault/SKILL.md`
+
+**Step 1: Create the sub-skill directory**
+
+```bash
+mkdir -p .claude/skills/_sub/project-sync-vault
+```
+
+**Step 2: Write the SKILL.md**
+
+Create `.claude/skills/_sub/project-sync-vault/SKILL.md`:
+
+```markdown
+---
+name: project-sync-vault
+description: Create or archive a project in the vault. Handles markdown file creation/movement and frontmatter updates.
+disable-model-invocation: true
+allowed-tools: Read, Write, Bash(ls, mv, mkdir)
+argument-hint: "action=create|archive project={{PROJECT}}"
+---
+
+# Project Sync Vault Sub-Skill
+
+Handles project lifecycle operations in the vault (markdown files).
+
+## Prerequisites
+
+This sub-skill expects:
+- `$VAULT` to be set by the calling skill
+- `project` data object passed via args
+
+## Arguments
+
+- `action` - Required. `create` or `archive`
+- `vault` - Required. Path to vault
+- `project` - Required. Project data object:
+  - `name` - Display name
+  - `slug` - URL-safe identifier
+  - `due_date` - YYYY-MM-DD
+  - `purpose` - Goal statement
+  - `outcomes[]` - Key outcomes (optional)
+  - `people[]` - Related people (optional)
+  - `path` - Existing file path (for archive action)
+
+---
+
+## Action: Create
+
+### 1. Build File Path
+
+```
+$VAULT/01_Projects/{due_date}-{slug}.md
+```
+
+Example: `$VAULT/01_Projects/2026-03-31-quarterly-planning.md`
+
+### 2. Check for Duplicates
+
+```bash
+ls "$VAULT/01_Projects/"*-{slug}.md 2>/dev/null
+```
+
+If exists, return error with suggestion to use different name.
+
+### 3. Generate Content
+
+Use project template structure:
+
+```markdown
+---
+title: {name}
+end_date: {due_date}
+status: active
+owner:
+tags: []
+---
+
+[[00_Brain/✱ Home|✱ Home]] | [[01_Projects/✱ Projects|✱ Projects]] | [[02_Areas/People/✱ People|✱ People]] | [[02_Areas/Insights/✱ Insights|✱ Insights]]
+
+---
+
+# {name}
+
+## Overview
+
+**Goal:** {purpose}
+
+**Why Now:** [To be filled]
+
+**End Date:** {due_date}
+
+---
+
+## Outcomes
+
+### Must Have
+{for each outcome: - [ ] {outcome}}
+
+### Should Have
+- [ ] [To be defined]
+
+### Could Have
+- [ ] [To be defined]
+
+---
+
+## Milestones
+
+| Date | Milestone | Status |
+|------|-----------|--------|
+| {due_date} | Project Complete | 🟡 Planned |
+
+*Status: 🟡 Planned | 🔵 In Progress | 🟢 Complete | 🔴 Blocked*
+
+---
+
+## Updates
+
+### {today} - Project Created
+- Goal: {purpose}
+{if people: - Key people: {people as wikilinks}}
+
+---
+
+## Resources
+
+### Links
+- [Add relevant links]
+
+### Related Projects
+- [Add related projects]
+
+### People
+{for each person: - [[02_Areas/People/{person}|{person}]]}
+
+---
+
+## Team
+
+| Name | Role | Involvement |
+|------|------|-------------|
+| [Name] | Project Lead | [Time commitment] |
+
+---
+
+## Archive Notes
+
+*When project completes, add final summary before moving to Archives:*
+
+**Final Status:**
+**Key Learnings:**
+**Impact:**
+```
+
+### 4. Write File
+
+Write the generated content to the file path.
+
+### 5. Return Result
+
+**Success:**
+```json
+{
+  "success": true,
+  "action": "create",
+  "path": "/path/to/vault/01_Projects/2026-03-31-quarterly-planning.md",
+  "slug": "quarterly-planning",
+  "message": "Project created successfully"
+}
+```
+
+**Error (duplicate):**
+```json
+{
+  "success": false,
+  "action": "create",
+  "error": "duplicate_slug",
+  "message": "Project with slug 'quarterly-planning' already exists",
+  "existing_path": "/path/to/existing.md",
+  "suggestion": "Use a different project name or archive the existing project first"
+}
+```
+
+---
+
+## Action: Archive
+
+### 1. Verify Source Exists
+
+Check that `project.path` exists and is in `01_Projects/`.
+
+### 2. Build Archive Path
+
+```
+$VAULT/04_Archives/Projects/{filename}
+```
+
+### 3. Ensure Archive Directory Exists
+
+```bash
+mkdir -p "$VAULT/04_Archives/Projects"
+```
+
+### 4. Read Current Content
+
+Read the project file to update frontmatter.
+
+### 5. Update Frontmatter
+
+Change `status: active` to `status: archived`.
+
+Add archive date: `archived_date: {today}`.
+
+### 6. Update Archive Notes Section
+
+If archive summary provided in project data, fill:
+- Final Status
+- Key Learnings
+- Impact
+
+### 7. Move File
+
+```bash
+mv "$VAULT/01_Projects/{filename}" "$VAULT/04_Archives/Projects/{filename}"
+```
+
+### 8. Return Result
+
+**Success:**
+```json
+{
+  "success": true,
+  "action": "archive",
+  "source_path": "/path/to/01_Projects/file.md",
+  "archive_path": "/path/to/04_Archives/Projects/file.md",
+  "message": "Project archived successfully"
+}
+```
+
+**Error:**
+```json
+{
+  "success": false,
+  "action": "archive",
+  "error": "source_not_found",
+  "message": "Project file not found at {path}"
+}
+```
+```
+
+**Step 3: Verify and commit**
+
+```bash
+git add .claude/skills/_sub/project-sync-vault/SKILL.md
+git commit -m "feat(sub-skill): add project-sync-vault for vault operations"
+```
+
+---
+
+## Task 3: project-sync-finder Stub
+
+**Files:**
+- Create: `.claude/skills/_sub/project-sync-finder/SKILL.md`
+
+**Step 1: Create the stub**
+
+```bash
+mkdir -p .claude/skills/_sub/project-sync-finder
+```
+
+**Step 2: Write minimal SKILL.md**
+
+Create `.claude/skills/_sub/project-sync-finder/SKILL.md`:
+
+```markdown
+---
+name: project-sync-finder
+description: "[NOT IMPLEMENTED] Create or archive project folders in Finder. Mirrors PARA structure in file system.
+disable-model-invocation: true
+allowed-tools: Bash(mkdir, mv, ls)
+argument-hint: "action=create|archive project={{PROJECT}}"
+---
+
+# Project Sync Finder Sub-Skill
+
+**Status:** Not implemented. This is a placeholder for future development.
+
+## Planned Functionality
+
+### Action: Create
+
+Create folder structure at `~/Projects/{due_date}-{slug}/`:
+- `Assets/` - Images, diagrams, etc.
+- `Documents/` - Working documents
+
+### Action: Archive
+
+Move project folder to `~/Projects/_Archive/`.
+
+## Interface
+
+Same as `project-sync-vault`:
+- Input: `action`, `vault`, `project` object
+- Output: `success`, `path`, `error`
+
+## Configuration
+
+Will read from `.claude/config.md`:
+```markdown
+finder_projects_path: ~/Projects
+```
+
+## Implementation Notes
+
+When implementing:
+1. Check if Finder integration is enabled in config
+2. Handle path expansion (`~` to full path)
+3. Create with proper permissions
+4. Handle existing folders gracefully
+```
+
+**Step 3: Commit**
+
+```bash
+git add .claude/skills/_sub/project-sync-finder/SKILL.md
+git commit -m "feat(sub-skill): add project-sync-finder stub"
+```
+
+---
+
+## Task 4: project-sync-outlook Stub
+
+**Files:**
+- Create: `.claude/skills/_sub/project-sync-outlook/SKILL.md`
+
+**Step 1: Create the stub**
+
+```bash
+mkdir -p .claude/skills/_sub/project-sync-outlook
+```
+
+**Step 2: Write minimal SKILL.md**
+
+Create `.claude/skills/_sub/project-sync-outlook/SKILL.md`:
+
+```markdown
+---
+name: project-sync-outlook
+description: "[NOT IMPLEMENTED] Create or archive project mail folders in Outlook365. PARA-aligned email organization."
+disable-model-invocation: true
+allowed-tools: Bash
+argument-hint: "action=create|archive project={{PROJECT}}"
+---
+
+# Project Sync Outlook Sub-Skill
+
+**Status:** Not implemented. This is a placeholder for future development.
+
+## Planned Functionality
+
+### Action: Create
+
+Create mail folder under `Projects/` in Outlook:
+- `Projects/{due_date}-{slug}/`
+
+### Action: Archive
+
+Move mail folder to `Projects/Archive/`.
+
+## Interface
+
+Same as `project-sync-vault`:
+- Input: `action`, `vault`, `project` object
+- Output: `success`, `folder_path`, `error`
+
+## Configuration
+
+Will read from `.claude/config.md`:
+```markdown
+outlook_enabled: true
+outlook_projects_folder: Projects
+```
+
+## Implementation Options
+
+1. **Microsoft Graph API** - Cross-platform, requires OAuth setup
+2. **AppleScript** - macOS only, simpler auth
+
+## Implementation Notes
+
+When implementing:
+1. Check if Outlook integration is enabled in config
+2. Authenticate with chosen method
+3. Handle folder creation/movement via API
+4. Return folder ID or path for reference
+```
+
+**Step 3: Commit**
+
+```bash
+git add .claude/skills/_sub/project-sync-outlook/SKILL.md
+git commit -m "feat(sub-skill): add project-sync-outlook stub"
+```
+
+---
+
+## Task 5: create-project Command Skill
+
+**Files:**
+- Create: `.claude/skills/commands/create-project/SKILL.md`
+- Create: `.claude/skills/commands/create-project/phases.yaml`
+
+**Step 1: Create directory**
+
+```bash
+mkdir -p .claude/skills/commands/create-project
+```
+
+**Step 2: Write SKILL.md**
+
+Create `.claude/skills/commands/create-project/SKILL.md`:
+
+```markdown
+---
+name: create-project
+description: Create a new project with guided setup. Syncs to vault (and future: Finder, Outlook).
+argument-hint: "[project-name]"
+metadata:
+  orchestrated: true
+  phases_file: phases.yaml
+---
+
+# Create Project
+
+Guided wizard to create a new project across synced tools.
+
+## Flow
+
+1. **Setup** — Load vault config, fetch existing projects (duplicate detection)
+2. **Interact** — Guided wizard: name, due date, purpose, outcomes, people
+3. **Generate** — Build project data object with slug
+4. **Sync** — Sequential sync to each enabled tool
+5. **Confirm** — Summary of created artifacts
+
+---
+
+## Interactive Wizard
+
+Ask questions one at a time. Use AskUserQuestion for structured choices where applicable.
+
+### Question 1: Project Name (required)
+
+"What's the project name?"
+
+Accept natural language. Generate slug from name:
+- Lowercase
+- Replace spaces with hyphens
+- Remove special characters
+- Max 50 characters
+
+Example: "Q2 Platform Migration" → `q2-platform-migration`
+
+### Question 2: Due Date (required)
+
+"When is this project due?"
+
+Accept flexible formats:
+- Exact: `2026-03-31`, `March 31`
+- Relative: `in 2 weeks`, `end of month`, `end of Q1`
+- Named: `end of March`, `mid April`
+
+Parse to YYYY-MM-DD format.
+
+### Question 3: Purpose (required)
+
+"In one sentence, what's the goal?"
+
+This becomes the Goal statement in the project file.
+
+### Question 4: Key Outcomes (optional)
+
+"What are the must-have outcomes? (Enter to skip)"
+
+Accept 1-3 bullet points. These populate the Must Have section.
+
+### Question 5: Related People (optional)
+
+"Who are the key people involved? (Enter to skip)"
+
+Accept comma-separated names. Creates wikilinks to `02_Areas/People/`.
+
+---
+
+## Generate
+
+Build project data object:
+
+```json
+{
+  "name": "Q2 Platform Migration",
+  "slug": "q2-platform-migration",
+  "due_date": "2026-03-31",
+  "purpose": "Complete migration of all services to new platform",
+  "outcomes": ["API migration", "Data migration", "Testing complete"],
+  "people": ["Alice", "Bob"]
+}
+```
+
+---
+
+## Sync Sequence
+
+Execute sync sub-skills in sequence. If one fails, report but continue to next.
+
+1. **sync-vault** (required) — Create markdown file
+2. **sync-finder** (optional, future) — Create folder structure
+3. **sync-outlook** (optional, future) — Create mail folder
+
+---
+
+## Confirm
+
+After all syncs complete, summarize:
+
+```
+Project created: Q2 Platform Migration
+
+✅ Vault: 01_Projects/2026-03-31-q2-platform-migration.md
+⏭️ Finder: Not enabled
+⏭️ Outlook: Not enabled
+
+Next steps:
+- Open the project file to add milestones
+- Link related documents and resources
+```
+```
+
+**Step 3: Write phases.yaml**
+
+Create `.claude/skills/commands/create-project/phases.yaml`:
+
+```yaml
+# Orchestration phases for create-project command
+
+phases:
+  # Phase 0: Setup (parallel, read-only)
+  - name: setup
+    parallel: true
+    subagents:
+      - skill: _sub/fetch-config
+        type: explore
+        output: VAULT
+      - skill: _sub/fetch-projects
+        type: explore
+        args: "scope=active"
+        output: EXISTING_PROJECTS
+
+  # Phase 1: Interactive Wizard (inline)
+  - name: interact
+    depends_on: [setup]
+    inline: true
+
+  # Phase 2: Generate Project Data (inline)
+  - name: generate
+    depends_on: [interact]
+    inline: true
+
+  # Phase 3: Sync to Vault (required)
+  - name: sync-vault
+    depends_on: [generate]
+    subagents:
+      - skill: _sub/project-sync-vault
+        type: general-purpose
+        args: "action=create vault={{VAULT}} project={{PROJECT}}"
+        output: VAULT_RESULT
+
+  # Phase 4: Sync to Finder (future, optional)
+  - name: sync-finder
+    depends_on: [sync-vault]
+    optional: true
+    enabled: false  # Enable when implemented
+    subagents:
+      - skill: _sub/project-sync-finder
+        type: general-purpose
+        args: "action=create project={{PROJECT}}"
+        output: FINDER_RESULT
+        on_error: "Finder sync skipped."
+
+  # Phase 5: Sync to Outlook (future, optional)
+  - name: sync-outlook
+    depends_on: [sync-finder]
+    optional: true
+    enabled: false  # Enable when implemented
+    subagents:
+      - skill: _sub/project-sync-outlook
+        type: general-purpose
+        args: "action=create project={{PROJECT}}"
+        output: OUTLOOK_RESULT
+        on_error: "Outlook sync skipped."
+
+  # Phase 6: Confirm (inline)
+  - name: confirm
+    depends_on: [sync-vault]
+    inline: true
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add .claude/skills/commands/create-project/
+git commit -m "feat(command): add create-project with vault sync"
+```
+
+---
+
+## Task 6: archive-project Command Skill
+
+**Files:**
+- Create: `.claude/skills/commands/archive-project/SKILL.md`
+- Create: `.claude/skills/commands/archive-project/phases.yaml`
+
+**Step 1: Create directory**
+
+```bash
+mkdir -p .claude/skills/commands/archive-project
+```
+
+**Step 2: Write SKILL.md**
+
+Create `.claude/skills/commands/archive-project/SKILL.md`:
+
+```markdown
+---
+name: archive-project
+description: Archive a completed project. Captures final summary and moves to archives across synced tools.
+argument-hint: "[project-slug]"
+metadata:
+  orchestrated: true
+  phases_file: phases.yaml
+---
+
+# Archive Project
+
+Guided workflow to archive a completed project across synced tools.
+
+## Flow
+
+1. **Setup** — Load vault config, fetch active projects
+2. **Select** — Choose project to archive
+3. **Interact** — Capture final summary (wins, learnings, impact)
+4. **Generate** — Build archive data
+5. **Sync** — Sequential sync to each enabled tool
+6. **Confirm** — Summary of archived artifacts
+
+---
+
+## Select Project
+
+Present list of active projects. If project slug provided as argument, validate it exists.
+
+```
+Active Projects:
+
+1. Q2 Platform Migration (due 2026-03-31) ✅ On Track
+2. Assessment Center Hiring (due 2026-02-20) ⚠️ Due Soon
+3. Team Offsite Planning (due 2026-04-15) ✅ On Track
+
+Which project to archive? [1-3 or slug]:
+```
+
+---
+
+## Interactive Summary
+
+Ask questions one at a time to capture archive summary.
+
+### Question 1: Final Status
+
+"How did the project end?"
+
+Options:
+- Completed successfully
+- Partially completed
+- Cancelled
+- On hold indefinitely
+
+### Question 2: Key Wins
+
+"What went well? What are you proud of?"
+
+Accept free text. 2-3 bullet points.
+
+### Question 3: Key Learnings
+
+"What would you do differently next time?"
+
+Accept free text. 2-3 bullet points.
+
+### Question 4: Impact
+
+"What was the actual outcome or impact?"
+
+Accept free text. Brief statement.
+
+### Question 5: Follow-ups
+
+"Any follow-up tasks or related projects? (Enter to skip)"
+
+Accept free text for items to carry forward.
+
+---
+
+## Generate
+
+Build archive data:
+
+```json
+{
+  "path": "/path/to/01_Projects/2026-03-31-q2-platform-migration.md",
+  "slug": "q2-platform-migration",
+  "archive_summary": {
+    "final_status": "Completed successfully",
+    "key_wins": ["Finished ahead of schedule", "Zero downtime migration"],
+    "key_learnings": ["Start testing earlier", "Document as you go"],
+    "impact": "All services now running on new platform with 40% cost reduction",
+    "follow_ups": ["Monitor performance for 30 days", "Schedule retrospective"]
+  }
+}
+```
+
+---
+
+## Sync Sequence
+
+Execute sync sub-skills in sequence.
+
+1. **sync-vault** (required) — Move file, update frontmatter
+2. **sync-finder** (optional, future) — Move folder to archive
+3. **sync-outlook** (optional, future) — Move mail folder to archive
+
+---
+
+## Confirm
+
+After all syncs complete, summarize:
+
+```
+Project archived: Q2 Platform Migration
+
+✅ Vault: Moved to 04_Archives/Projects/2026-03-31-q2-platform-migration.md
+⏭️ Finder: Not enabled
+⏭️ Outlook: Not enabled
+
+Final status: Completed successfully
+Key impact: All services now running on new platform with 40% cost reduction
+
+Follow-ups to consider:
+- Monitor performance for 30 days
+- Schedule retrospective
+```
+```
+
+**Step 3: Write phases.yaml**
+
+Create `.claude/skills/commands/archive-project/phases.yaml`:
+
+```yaml
+# Orchestration phases for archive-project command
+
+phases:
+  # Phase 0: Setup (parallel, read-only)
+  - name: setup
+    parallel: true
+    subagents:
+      - skill: _sub/fetch-config
+        type: explore
+        output: VAULT
+      - skill: _sub/fetch-projects
+        type: explore
+        args: "scope=active"
+        output: ACTIVE_PROJECTS
+
+  # Phase 1: Select Project (inline)
+  - name: select
+    depends_on: [setup]
+    inline: true
+
+  # Phase 2: Interactive Summary (inline)
+  - name: interact
+    depends_on: [select]
+    inline: true
+
+  # Phase 3: Generate Archive Data (inline)
+  - name: generate
+    depends_on: [interact]
+    inline: true
+
+  # Phase 4: Sync to Vault (required)
+  - name: sync-vault
+    depends_on: [generate]
+    subagents:
+      - skill: _sub/project-sync-vault
+        type: general-purpose
+        args: "action=archive vault={{VAULT}} project={{PROJECT}}"
+        output: VAULT_RESULT
+
+  # Phase 5: Sync to Finder (future, optional)
+  - name: sync-finder
+    depends_on: [sync-vault]
+    optional: true
+    enabled: false
+    subagents:
+      - skill: _sub/project-sync-finder
+        type: general-purpose
+        args: "action=archive project={{PROJECT}}"
+        output: FINDER_RESULT
+        on_error: "Finder sync skipped."
+
+  # Phase 6: Sync to Outlook (future, optional)
+  - name: sync-outlook
+    depends_on: [sync-finder]
+    optional: true
+    enabled: false
+    subagents:
+      - skill: _sub/project-sync-outlook
+        type: general-purpose
+        args: "action=archive project={{PROJECT}}"
+        output: OUTLOOK_RESULT
+        on_error: "Outlook sync skipped."
+
+  # Phase 7: Confirm (inline)
+  - name: confirm
+    depends_on: [sync-vault]
+    inline: true
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add .claude/skills/commands/archive-project/
+git commit -m "feat(command): add archive-project with vault sync"
+```
+
+---
+
+## Task 7: Update Issue #2
+
+**Files:**
+- Modify: GitHub issue #2
+
+**Step 1: Update issue body**
+
+Update issue #2 to reflect the redesigned scope:
+
+1. Update the summary to reference the design doc
+2. Mark Phase 1 sub-issues as the current scope
+3. Move Finder (#6) and Outlook (#7) to Phase 2/3 section
+4. Add link to design doc
+
+**Step 2: Update sub-issue checkboxes**
+
+Phase 1 (MVP):
+- [ ] #3 - Implement create-project → covered by Task 5
+- [ ] #4 - Implement archive-project → covered by Task 6
+- [ ] #5 - Implement fetch-projects → covered by Task 1
+- [ ] #8 - Update documentation → Task 8
+
+Phase 2+ (Future):
+- [ ] #6 - Finder integration (stub created)
+- [ ] #7 - Outlook integration (stub created)
+
+---
+
+## Task 8: Update Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (add commands to quick reference)
+- Modify: `README.md` (add project commands to usage)
+
+**Step 1: Update CLAUDE.md quick reference**
+
+Add to the Quick Reference section:
+
+```markdown
+claude skill run commands/create-project    # new project
+claude skill run commands/archive-project   # archive completed project
+```
+
+**Step 2: Update README.md**
+
+Add project commands to the usage documentation, explaining:
+- How to create a new project
+- How to archive a completed project
+- Future: Finder and Outlook integrations
+
+**Step 3: Commit documentation**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "docs: add project lifecycle commands to documentation"
+```
+
+---
+
+## Task 9: Final Verification
+
+**Step 1: List all new skills**
+
+```bash
+find .claude/skills -name "SKILL.md" | grep -E "(fetch-projects|project-sync|create-project|archive-project)" | sort
+```
+
+Expected output:
+```
+.claude/skills/_sub/fetch-projects/SKILL.md
+.claude/skills/_sub/project-sync-finder/SKILL.md
+.claude/skills/_sub/project-sync-outlook/SKILL.md
+.claude/skills/_sub/project-sync-vault/SKILL.md
+.claude/skills/commands/archive-project/SKILL.md
+.claude/skills/commands/create-project/SKILL.md
+```
+
+**Step 2: Verify phases.yaml files**
+
+```bash
+find .claude/skills -name "phases.yaml" | grep -E "(create-project|archive-project)" | sort
+```
+
+Expected:
+```
+.claude/skills/commands/archive-project/phases.yaml
+.claude/skills/commands/create-project/phases.yaml
+```
+
+**Step 3: Verify git history**
+
+```bash
+git log --oneline -10
+```
+
+Verify commits for:
+- fetch-projects sub-skill
+- project-sync-vault sub-skill
+- project-sync-finder stub
+- project-sync-outlook stub
+- create-project command
+- archive-project command
+- documentation updates
+
+---
+
+## Summary
+
+**Sub-skills created (4):**
+- `_sub/fetch-projects` — List projects for selection
+- `_sub/project-sync-vault` — Create/archive in vault (implemented)
+- `_sub/project-sync-finder` — Finder integration (stub)
+- `_sub/project-sync-outlook` — Outlook integration (stub)
+
+**Commands created (2):**
+- `commands/create-project` — Interactive wizard + sequential sync
+- `commands/archive-project` — Project selection + archive summary + sequential sync
+
+**Architecture:**
+- Sequential sync phases for partial success
+- Shared interface across all sync sub-skills
+- Optional phases for future tools (no main skill changes needed)
+- `enabled: false` flag for unimplemented sync phases
+
+**Total commits: 8**


### PR DESCRIPTION
## Summary

Implements the core project lifecycle skills from #2:

- `_sub/fetch-projects` — List projects from vault with timeline urgency
- `_sub/project-sync-vault` — Create/archive project files in vault
- `_sub/project-sync-finder` — Stub for future Finder integration
- `_sub/project-sync-outlook` — Stub for future Outlook integration
- `commands/create-project` — Interactive wizard to create new projects
- `commands/archive-project` — Archive completed projects with summary capture

Architecture uses sequential sync phases for extensibility — new tools can be added as sub-skills without changing main commands.

Closes #2 (Phase 1)

## Test Plan

- [ ] Run `/create-project` and verify project file created in `01_Projects/`
- [ ] Run `/archive-project` and verify file moved to `04_Archives/Projects/`
- [ ] Verify frontmatter updated correctly on archive